### PR TITLE
Have taken several things out from hard-coding and optimising the performance a bit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 	"require": {
 		"spatie/laravel-activitylog": "^3.0",
 		"illuminate/support": "^8.0",
-		"tcg/voyager": "^1.3"
+		"tcg/voyager": "*"
 	},
 	"require-dev": {
 		"orchestra/testbench": "^4.0"

--- a/publishable/config/activitylog-ui.php
+++ b/publishable/config/activitylog-ui.php
@@ -1,5 +1,5 @@
 <?php
 return [
-	'user_model' => '\App\User',
+	'user_model' => ['\App\User'],
 	'middleware' => ['auth'],
 ];

--- a/routes.php
+++ b/routes.php
@@ -4,6 +4,6 @@ use Illuminate\Support\Facades\Route;
 use Damms005\LaravelActivitylogUi\Http\Controllers\ActivitylogUiController;
 
 Route::group(['prefix' => '/admin/activitylog-ui', 'middleware' => ['web', 'auth']], function () {
-	Route::get('/', [ActivitylogUiController::class, "index"]);
+	Route::get('/', [ActivitylogUiController::class, "index"])->name('activitylog.index');
 	Route::post('submit', [ActivitylogUiController::class, "show"])->name('activitylog.filter.submit');
 });

--- a/routes.php
+++ b/routes.php
@@ -5,5 +5,5 @@ use Damms005\LaravelActivitylogUi\Http\Controllers\ActivitylogUiController;
 
 Route::group(['prefix' => '/admin/activitylog-ui', 'middleware' => ['web', 'auth']], function () {
 	Route::get('/', [ActivitylogUiController::class, "index"])->name('activitylog.index');
-	Route::post('submit', [ActivitylogUiController::class, "show"])->name('activitylog.filter.submit');
+	Route::any('submit', [ActivitylogUiController::class, "show"])->name('activitylog.filter.submit');
 });

--- a/src/ActivitylogUiServiceProvider.php
+++ b/src/ActivitylogUiServiceProvider.php
@@ -26,5 +26,9 @@ class ActivitylogUiServiceProvider extends ServiceProvider
 	{
 		$this->loadRoutesFrom(__DIR__ . '/../routes.php');
 		$this->loadViewsFrom(__DIR__ . '/../views', 'activitylog-ui');
+
+		$this->publishes([
+				__DIR__ . '/../publishable/config/activitylog-ui.php' => config_path('activitylog-ui.php')
+		]);
 	}
 }

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -53,7 +53,7 @@ class ActivitylogUiController extends Controller
 		}
 
 		if ($request->filled('to')) {
-			$builder = $builder->where('created_at', '<=', "{$request->to} 11:59:59");
+			$builder = $builder->where('created_at', '<=', "{$request->to} 23:59:59");
 		}
 
 		if ($request->filled('contain_data')) {

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -100,7 +100,7 @@ class ActivitylogUiController extends Controller
 
 			$dataType = Voyager::model('DataType')->whereName($model->getTable())->first();
 
-			$voyagerSlug = $activity->description != 'deleted' ? $dataType->slug : null;
+			$voyagerSlug = $activity->description != 'deleted' ? data_get($dataType, 'slug', '') : null;
 
 			$obj->put('link', $this->getVoyagerLinkTagForTable($voyagerSlug, $id, "id:{$id}"));
 		} else {

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -27,6 +27,10 @@ class ActivitylogUiController extends Controller
 	{
 		$builder = Activity::with('causer', 'subject');
 
+		if ($request->filled('causer_type')) {
+			$builder = $builder->where('causer_type', $request->causer_type);
+		}
+
 		if ($request->filled('causer_id')) {
 			$builder = $builder->where('causer_id', $request->causer_id);
 		}

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -112,10 +112,8 @@ class ActivitylogUiController extends Controller
 
 	public function getVoyagerLinkTagForTable($voyager_slug, $id, $anchorText)
 	{
-		if ($this->isVoyagerUserExists($activity)) {
-			$model = Voyager::model('DataType')->where('model_name', $activity->causer_type)->first();
-			$slug = $model ? $model->slug : 'users';
-			return $this->getVoyagerLinkTagForTable($slug, $activity->causer_id, optional($activity->causer)->fullname . ' (' . $activity->causer_id . ')');
+		if ($this->isVoyagerRouteExists($voyager_slug)) {
+			return collect(['href' => route("voyager.{$voyager_slug}.index") . '/' . $id, 'anchorText' => $anchorText]);
 		}
 
 		return collect(['href' => 'javascript:void(0)', 'anchorText' => $anchorText]);
@@ -124,7 +122,9 @@ class ActivitylogUiController extends Controller
 	public function getVoyagerLinkOrLabelForCauser(Activity $activity)
 	{
 		if ($this->isVoyagerUserExists($activity)) {
-			return $this->getVoyagerLinkTagForTable('users', $activity->causer_id, optional($activity->causer)->fullname . ' (' . $activity->causer_id . ')');
+			$model = Voyager::model('DataType')->where('model_name', $activity->causer_type)->first();
+			$slug = $model ? $model->slug : 'users';
+			return $this->getVoyagerLinkTagForTable($slug, $activity->causer_id, optional($activity->causer)->fullname . ' (' . $activity->causer_id . ')');
 		}
 
 		return $this->getVoyagerLinkTagForTable(null, null, 'system anonymous action');

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -19,9 +19,9 @@ class ActivitylogUiController extends Controller
 
 		$this->mapActivitiesForView($rendered_activities);
 
-		$all_activities = Activity::all(['description', 'subject_type']);
+		list($descriptions, $subject_types) = $this->getOptions();
 
-		return view('activitylog-ui::index', compact('rendered_activities', 'all_activities'));
+		return view('activitylog-ui::index', compact('rendered_activities', 'descriptions', 'subject_types'));
 	}
 
 	public function show(Request $request)
@@ -66,13 +66,23 @@ class ActivitylogUiController extends Controller
 
 		$request->flash();
 
+        list($descriptions, $subject_types) = $this->getOptions();
+
+		return view('activitylog-ui::index', compact('rendered_activities', 'descriptions', 'subject_types'));
+	}
+
+    protected function getOptions()
+    {
+
         $descriptions = [
             'created', 'updated', 'deleted'
         ];
         $subject_types = Activity::select('subject_type')->distinct()->get()->pluck('subject_type')->all();
 
-		return view('activitylog-ui::index', compact('rendered_activities', 'descriptions', 'subject_types'));
-	}
+        return [
+            $descriptions, $subject_types
+        ];
+    }
 
 	/**
 	 * Formats each item in the activities collection so that

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -15,6 +15,8 @@ class ActivitylogUiController extends Controller
 {
 	public function index(Request $request)
 	{
+		$request->flush();
+
 		$rendered_activities = Activity::with('causer', 'subject')->orderBy('id', 'desc')->paginate(15);
 
 		$this->mapActivitiesForView($rendered_activities);

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Spatie\Activitylog\Models\Activity;
 use TCG\Voyager\Facades\Voyager;
@@ -65,9 +66,12 @@ class ActivitylogUiController extends Controller
 
 		$request->flash();
 
-		$all_activities = Activity::all(['description', 'subject_type']);
+        $descriptions = [
+            'created', 'updated', 'deleted'
+        ];
+        $subject_types = Activity::select('subject_type')->distinct()->get()->pluck('subject_type')->all();
 
-		return view('activitylog-ui::index', compact('rendered_activities', 'all_activities'));
+		return view('activitylog-ui::index', compact('rendered_activities', 'descriptions', 'subject_types'));
 	}
 
 	/**
@@ -126,8 +130,8 @@ class ActivitylogUiController extends Controller
 	public function getVoyagerLinkOrLabelForCauser(Activity $activity)
 	{
 		if ($this->isVoyagerUserExists($activity)) {
-			$model = Voyager::model('DataType')->where('model_name', $activity->causer_type)->first();
-			$slug = $model ? $model->slug : 'users';
+            $model = Voyager::model('DataType')->where('model_name', $activity->causer_type)->first();
+            $slug = $model ? $model->slug : 'users';
 			return $this->getVoyagerLinkTagForTable($slug, $activity->causer_id, optional($activity->causer)->fullname . ' (' . $activity->causer_id . ')');
 		}
 

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -112,8 +112,10 @@ class ActivitylogUiController extends Controller
 
 	public function getVoyagerLinkTagForTable($voyager_slug, $id, $anchorText)
 	{
-		if ($this->isVoyagerRouteExists($voyager_slug)) {
-			return collect(['href' => route("voyager.{$voyager_slug}.index") . '/' . $id, 'anchorText' => $anchorText]);
+		if ($this->isVoyagerUserExists($activity)) {
+			$model = Voyager::model('DataType')->where('model_name', $activity->causer_type)->first();
+			$slug = $model ? $model->slug : 'users';
+			return $this->getVoyagerLinkTagForTable($slug, $activity->causer_id, optional($activity->causer)->fullname . ' (' . $activity->causer_id . ')');
 		}
 
 		return collect(['href' => 'javascript:void(0)', 'anchorText' => $anchorText]);
@@ -122,7 +124,7 @@ class ActivitylogUiController extends Controller
 	public function getVoyagerLinkOrLabelForCauser(Activity $activity)
 	{
 		if ($this->isVoyagerUserExists($activity)) {
-			return $this->getVoyagerLinkTagForTable('users', $activity->causer_id, optional($activity->causer)->fullname);
+			return $this->getVoyagerLinkTagForTable('users', $activity->causer_id, optional($activity->causer)->fullname . ' (' . $activity->causer_id . ')');
 		}
 
 		return $this->getVoyagerLinkTagForTable(null, null, 'system anonymous action');
@@ -130,7 +132,7 @@ class ActivitylogUiController extends Controller
 
 	public function isVoyagerUserExists(Activity $activity)
 	{
-		return $activity->causer_id && Route::has('voyager.users.index');
+		return $activity->causer_id;// && Route::has('voyager.admin-users.index');
 	}
 
 	public function isVoyagerRouteExists($voyager_slug)

--- a/src/Http/Controllers/ActivitylogUiController.php
+++ b/src/Http/Controllers/ActivitylogUiController.php
@@ -90,7 +90,8 @@ class ActivitylogUiController extends Controller
 	{
 		$obj = collect();
 
-		$model = $activity->subject_type::where('id', $activity->subject_id)->first();
+        $keyName = app($activity->subject_type)->getKeyName();
+		$model = $activity->subject_type::where($keyName, $activity->subject_id)->first();
 
 		$obj->put('modelClassName', collect(explode('\\', $activity->subject_type))->last());
 

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -51,6 +51,8 @@
 							<input value="{{old('subject_id')}}" name="subject_id" class="h-10 w-16" type="number">
 						</label>
 
+						<br>
+
 						Action
 						<label class="w-24 mr-2">
 							<select name="description" class="select" style="height: 28px">
@@ -77,6 +79,7 @@
 						</label>
 
 						<input class="bg-green-dark rounded p-2 px-4 text-white" type="submit" value="Audit" />
+						<a class="bg-green-dark rounded p-2 px-4 text-white" href="{{ route('activitylog.index') }}">Clear filter</a>
 					</div>
 				</form>
 			</div>

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -25,7 +25,7 @@
 						<hr>
 						Causer
 						<label class="w-64 mr-2">
-							<select name="causer_type" class="select">
+							<select name="causer_type" class="select" style="height: 28px">
 								<option value="">&nbsp;</option>
 								@foreach (config('activitylog-ui.user_model') as $type)
 								<option {{ $type == old('causer_type') ? 'selected' : '' }} value="{{$type}}">{{(new \ReflectionClass($type))->getShortName()}}</option>
@@ -38,10 +38,10 @@
 
 						Acted-on Entity
 						<label class="w-64 mr-2">
-							<select name="subject_type" class="select2">
+							<select name="subject_type" class="select" style="height: 28px">
 								<option value="">&nbsp;</option>
-								@foreach ($all_activities->unique('subject_type') as $activity)
-								<option {{ $activity->subject_type == old('subject_type') ? 'selected' : '' }}>{{$activity->subject_type}}</option>
+								@foreach ($subject_types as $subject_type)
+								<option {{ $subject_type == old('subject_type') ? 'selected' : '' }}>{{(new \ReflectionClass($subject_type))->getShortName()}}</option>
 								@endforeach
 							</select>
 						</label>
@@ -53,10 +53,10 @@
 
 						Action
 						<label class="w-24 mr-2">
-							<select name="description" class="select2">
+							<select name="description" class="select" style="height: 28px">
 								<option value="">&nbsp;</option>
-								@foreach ($all_activities->unique('description') as $activity)
-								<option {{ $activity->description == old('description') ? 'selected' : '' }}>{{$activity->description}}</option>
+								@foreach ($descriptions as $description)
+								<option {{ $description == old('description') ? 'selected' : '' }}>{{$description}}</option>
 								@endforeach
 							</select>
 						</label>

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -18,7 +18,7 @@
 		<div class="col-md-12">
 
 			<div class="bg-blue-lighteR rounded border mt-8 mb-8 p-4">
-				<form action="{{route('activitylog.filter.submit')}}" method="POST">
+				<form action="{{route('activitylog.filter.submit')}}" method="GET">
 					@csrf
 					<div>
 						<h4>Audit</h4>

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -41,7 +41,7 @@
 							<select name="subject_type" class="select" style="height: 28px">
 								<option value="">&nbsp;</option>
 								@foreach ($subject_types as $subject_type)
-								<option {{ $subject_type == old('subject_type') ? 'selected' : '' }}>{{(new \ReflectionClass($subject_type))->getShortName()}}</option>
+								<option value="{{$subject_type}}" {{ $subject_type == old('subject_type') ? 'selected' : '' }}>{{(new \ReflectionClass($subject_type))->getShortName()}}</option>
 								@endforeach
 							</select>
 						</label>

--- a/views/index.blade.php
+++ b/views/index.blade.php
@@ -25,12 +25,15 @@
 						<hr>
 						Causer
 						<label class="w-64 mr-2">
-							<select name="causer_id" class="select2">
+							<select name="causer_type" class="select">
 								<option value="">&nbsp;</option>
-								@foreach (\App\User::all() as $user)
-								<option {{ $user->id == old('causer_id') ? 'selected' : '' }} value="{{$user->id}}">{{$user->email}})</option>
+								@foreach (config('activitylog-ui.user_model') as $type)
+								<option {{ $type == old('causer_type') ? 'selected' : '' }} value="{{$type}}">{{(new \ReflectionClass($type))->getShortName()}}</option>
 								@endforeach
 							</select>
+						</label>
+						<label class="w-64 mr-2">
+                            <input value="{{old('causer_id')}}" name="causer_id" class="h-10 w-16" type="number">
 						</label>
 
 						Acted-on Entity


### PR DESCRIPTION
Have made a few changes to fit my project's need and think it may be useful for others.

* Support using field other than the "id" field as the primary key
* Support showing models, which are not using BREAD, in the list
* Support multiple user types (configurable), since there could be admin users, normal users
* Don't scan all activities for computing the subject type dropdown and description dropdown